### PR TITLE
Implement typed terminals

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -149,6 +149,11 @@ impl Component for App {
                                     *geometry = new_geometry;
                                 }
                             }
+                            ModelOp::UpdateModuleIndication(id, new_indication) => {
+                                if let Some(indication) = state.indications.get_mut(&id) {
+                                    *indication = new_indication;
+                                }
+                            }
                             ModelOp::DeleteModule(id) => {
                                 state.modules.remove(&id);
                                 state.geometry.remove(&id);
@@ -161,16 +166,6 @@ impl Component for App {
                                 state.connections.remove(&input);
                             }
                         }
-
-                        self.state_seq += 1;
-                        true
-                    }
-                    ServerMessage::Indication(module_id, indication) => {
-                        let mut state = self.state.as_ref()
-                            .expect("server should always send a WorkspaceState before an Indication")
-                            .borrow_mut();
-
-                        state.indications.insert(module_id, indication);
 
                         self.state_seq += 1;
                         true

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -134,8 +134,8 @@ impl Component for App {
                             .borrow_mut();
 
                         match op {
-                            ModelOp::CreateModule(id, module, geometry, indication) => {
-                                state.modules.insert(id, module);
+                            ModelOp::CreateModule { id, params, geometry, indication, inputs, outputs } => {
+                                state.modules.insert(id, params);
                                 state.geometry.insert(id, geometry);
                                 state.indications.insert(id, indication);
                             }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -15,7 +15,7 @@ use yew::format::Binary;
 use yew::services::websocket::{WebSocketService, WebSocketStatus, WebSocketTask};
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
 
-use mixlab_protocol::{ClientMessage, WorkspaceState, ServerMessage, ModuleId, InputId, OutputId, ModuleParams, WindowGeometry, ModelOp, Indication};
+use mixlab_protocol::{ClientMessage, WorkspaceState, ServerMessage, ModuleId, InputId, OutputId, ModuleParams, WindowGeometry, ModelOp, Indication, LineType};
 
 use workspace::Workspace;
 
@@ -38,6 +38,8 @@ pub struct State {
     geometry: HashMap<ModuleId, WindowGeometry>,
     connections: HashMap<InputId, OutputId>,
     indications: HashMap<ModuleId, Indication>,
+    inputs: HashMap<ModuleId, Vec<LineType>>,
+    outputs: HashMap<ModuleId, Vec<LineType>>,
 }
 
 impl From<WorkspaceState> for State {
@@ -47,6 +49,8 @@ impl From<WorkspaceState> for State {
             geometry: wstate.geometry.into_iter().collect(),
             indications: wstate.indications.into_iter().collect(),
             connections: wstate.connections.into_iter().collect(),
+            inputs: wstate.inputs.into_iter().collect(),
+            outputs: wstate.outputs.into_iter().collect(),
         }
     }
 }
@@ -138,6 +142,8 @@ impl Component for App {
                                 state.modules.insert(id, params);
                                 state.geometry.insert(id, geometry);
                                 state.indications.insert(id, indication);
+                                state.inputs.insert(id, inputs);
+                                state.outputs.insert(id, outputs);
                             }
                             ModelOp::UpdateModuleParams(id, new_params) => {
                                 if let Some(params) = state.modules.get_mut(&id) {
@@ -158,6 +164,8 @@ impl Component for App {
                                 state.modules.remove(&id);
                                 state.geometry.remove(&id);
                                 state.indications.remove(&id);
+                                state.inputs.remove(&id);
+                                state.outputs.remove(&id);
                             }
                             ModelOp::CreateConnection(input, output) => {
                                 state.connections.insert(input, output);

--- a/frontend/src/workspace.rs
+++ b/frontend/src/workspace.rs
@@ -750,9 +750,10 @@ impl Component for Terminal {
             >
                 <svg width="16" height="16">
                     { match self.props.terminal.line_type {
+                        LineType::Mono => html! {},
                         LineType::Stereo => html! {
                             <polygon points="0,16 16,16 16,0" fill={ if self.hover { "#f0b5b3" } else { "#e0a5a3" } } />
-                        }
+                        },
                     } }
                 </svg>
             </div>

--- a/frontend/src/workspace.rs
+++ b/frontend/src/workspace.rs
@@ -497,6 +497,8 @@ impl Workspace {
             ("FM Sine", ModuleParams::FmSine(FmSineParams { freq_lo: 90.0, freq_hi: 110.0 })),
             ("Amplifier", ModuleParams::Amplifier(AmplifierParams { amplitude: 1.0, mod_depth: 0.5 })),
             ("Trigger", ModuleParams::Trigger(GateState::Closed)),
+            ("Stereo Panner", ModuleParams::StereoPanner(())),
+            ("Stereo Splitter", ModuleParams::StereoSplitter(())),
         ];
 
         html! {
@@ -687,7 +689,9 @@ impl Window {
             ModuleParams::SineGenerator(params) => {
                 html! { <SineGenerator id={self.props.id} module={self.link.clone()} params={params} /> }
             }
-            ModuleParams::Mixer2ch(_) => {
+            ModuleParams::Mixer2ch(()) |
+            ModuleParams::StereoPanner(()) |
+            ModuleParams::StereoSplitter(()) => {
                 html! {}
             }
             ModuleParams::OutputDevice(params) => {

--- a/frontend/src/workspace.rs
+++ b/frontend/src/workspace.rs
@@ -649,28 +649,26 @@ impl Component for Window {
 
 impl Window {
     fn view_inputs(&self) -> Html {
-        html! {
-            { for self.props.refs.inputs.iter().cloned().enumerate().map(|(index, terminal_ref)| {
-                let terminal_id = TerminalId::Input(InputId(self.props.id, index));
-
-                html! {
-                    <Terminal
-                        terminal={terminal_ref.clone()}
-                        onmousedown={self.link.callback({
-                            let terminal_ref = terminal_ref.clone();
-                            move |ev| WindowMsg::TerminalMouseDown(ev, terminal_id, terminal_ref.clone())
-                        })}
-                    />
-                }
-            }) }
-        }
+        self.view_terminals(
+            self.props.refs.inputs.iter()
+                .cloned()
+                .enumerate()
+                .map(|(index, terminal_ref)|
+                    (TerminalId::Input(InputId(self.props.id, index)), terminal_ref)))
     }
 
     fn view_outputs(&self) -> Html {
-        html! {
-            { for self.props.refs.outputs.iter().cloned().enumerate().map(|(index, terminal_ref)| {
-                let terminal_id = TerminalId::Output(OutputId(self.props.id, index));
+        self.view_terminals(
+            self.props.refs.outputs.iter()
+                .cloned()
+                .enumerate()
+                .map(|(index, terminal_ref)|
+                    (TerminalId::Output(OutputId(self.props.id, index)), terminal_ref)))
+    }
 
+    fn view_terminals(&self, terminals: impl Iterator<Item = (TerminalId, TerminalRef)>) -> Html {
+        html! {
+            { for terminals.map(|(terminal_id, terminal_ref)| {
                 html! {
                     <Terminal
                         terminal={terminal_ref.clone()}

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -99,21 +99,25 @@ pub enum LineType {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ModuleParams {
-    SineGenerator(SineGeneratorParams),
-    OutputDevice(OutputDeviceParams),
-    Mixer2ch(()),
-    FmSine(FmSineParams),
     Amplifier(AmplifierParams),
+    FmSine(FmSineParams),
+    Mixer2ch(()),
+    OutputDevice(OutputDeviceParams),
+    SineGenerator(SineGeneratorParams),
+    StereoPanner(()),
+    StereoSplitter(()),
     Trigger(GateState),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Indication {
-    SineGenerator(()),
-    OutputDevice(OutputDeviceIndication),
-    Mixer2ch(()),
-    FmSine(()),
     Amplifier(()),
+    FmSine(()),
+    Mixer2ch(()),
+    OutputDevice(OutputDeviceIndication),
+    SineGenerator(()),
+    StereoPanner(()),
+    StereoSplitter(()),
     Trigger(()),
 }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -12,6 +12,8 @@ pub struct WorkspaceState {
     pub geometry: Vec<(ModuleId, WindowGeometry)>,
     pub indications: Vec<(ModuleId, Indication)>,
     pub connections: Vec<(InputId, OutputId)>,
+    pub inputs: Vec<(ModuleId, Vec<LineType>)>,
+    pub outputs: Vec<(ModuleId, Vec<LineType>)>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -30,7 +30,14 @@ pub struct LogPosition(pub usize);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ModelOp {
-    CreateModule(ModuleId, ModuleParams, WindowGeometry, Indication),
+    CreateModule {
+        id: ModuleId,
+        params: ModuleParams,
+        geometry: WindowGeometry,
+        indication: Indication,
+        inputs: Vec<LineType>,
+        outputs: Vec<LineType>,
+    },
     UpdateModuleParams(ModuleId, ModuleParams),
     UpdateWindowGeometry(ModuleId, WindowGeometry),
     DeleteModule(ModuleId),
@@ -82,7 +89,7 @@ impl OutputId {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LineType {
     Stereo,
 }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -93,6 +93,7 @@ impl OutputId {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LineType {
+    Mono,
     Stereo,
 }
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -4,7 +4,6 @@ use serde_derive::{Serialize, Deserialize};
 pub enum ServerMessage {
     WorkspaceState(WorkspaceState),
     ModelOp(LogPosition, ModelOp),
-    Indication(ModuleId, Indication),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -40,6 +39,7 @@ pub enum ModelOp {
     },
     UpdateModuleParams(ModuleId, ModuleParams),
     UpdateWindowGeometry(ModuleId, WindowGeometry),
+    UpdateModuleIndication(ModuleId, Indication),
     DeleteModule(ModuleId),
     CreateConnection(InputId, OutputId),
     DeleteConnection(InputId),

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -82,6 +82,11 @@ impl OutputId {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum LineType {
+    Stereo,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ModuleParams {
     SineGenerator(SineGeneratorParams),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -338,11 +338,21 @@ impl Engine {
                 // window geometry and so should not own this data and force
                 // all accesses to it to go via the live audio thread
                 let id = ModuleId(self.module_seq.next());
-                let (module, indications) = Module::create(params.clone());
+                let (module, indication) = Module::create(params.clone());
+                let inputs = module.inputs().to_vec();
+                let outputs = module.outputs().to_vec();
                 self.modules.insert(id, module);
                 self.geometry.insert(id, geometry.clone());
-                self.indications.insert(id, indications.clone());
-                self.log_op(ModelOp::CreateModule(id, params, geometry, indications));
+                self.indications.insert(id, indication.clone());
+
+                self.log_op(ModelOp::CreateModule {
+                    id,
+                    params,
+                    geometry,
+                    indication,
+                    inputs,
+                    outputs,
+                });
             }
             ClientMessage::UpdateModuleParams(module_id, params) => {
                 if let Some(module) = self.modules.get_mut(&module_id) {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::f32;
 use std::sync::mpsc::{self, SyncSender, Receiver, RecvTimeoutError, TrySendError};
 use std::thread;
@@ -445,18 +445,18 @@ impl Engine {
             terminal_modules.remove(&output.module_id());
         }
 
-        // breadth-first-search modules out via their inputs, starting from
+        // depth-first-search modules out via their inputs, starting from
         // terminal modules
 
         let mut reverse_module_order = Vec::new();
         let mut visited_modules = HashSet::new();
-        let mut module_queue = VecDeque::new();
+        let mut module_stack = Vec::new();
 
         for id in terminal_modules.into_iter() {
-            module_queue.push_back(id);
+            module_stack.push(id);
         }
 
-        while let Some(module_id) = module_queue.pop_front() {
+        while let Some(module_id) = module_stack.pop() {
             let module = &self.modules[&module_id];
 
             // skip module if visited already
@@ -473,7 +473,7 @@ impl Engine {
                 let terminal_id = InputId(module_id, i);
 
                 if let Some(output_id) = self.connections.get(&terminal_id) {
-                    module_queue.push_back(output_id.module_id());
+                    module_stack.push(output_id.module_id());
                 }
             }
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -300,10 +300,14 @@ impl Engine {
             geometry: Vec::new(),
             indications: Vec::new(),
             connections: Vec::new(),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
         };
 
         for (module_id, module) in &self.modules {
             state.modules.push((*module_id, module.params()));
+            state.inputs.push((*module_id, module.inputs().to_vec()));
+            state.outputs.push((*module_id, module.outputs().to_vec()));
         }
 
         for (module_id, geometry) in &self.geometry {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use warp::reply::{self, Reply};
 use warp::ws::{self, Ws, WebSocket};
 
 use engine::EngineHandle;
-use mixlab_protocol::{ClientMessage, ServerMessage, ModelOp, LogPosition, ModuleId, Indication};
+use mixlab_protocol::{ClientMessage, ServerMessage, ModelOp, LogPosition};
 
 fn content(content_type: &str, reply: impl Reply) -> impl Reply {
     reply::with_header(reply, "content-type", content_type)
@@ -45,7 +45,7 @@ fn wasm() -> impl Reply {
 async fn session(websocket: WebSocket, engine: Arc<EngineHandle>) {
     let (mut tx, rx) = websocket.split();
 
-    let (state, model_ops, indics, engine) = engine.connect().await
+    let (state, model_ops, engine) = engine.connect().await
         .expect("engine.connect");
 
     let state_msg = bincode::serialize(&ServerMessage::WorkspaceState(state))
@@ -58,15 +58,11 @@ async fn session(websocket: WebSocket, engine: Arc<EngineHandle>) {
     enum Event {
         ClientMessage(Result<ws::Message, warp::Error>),
         ModelOp(Result<(LogPosition, ModelOp), broadcast::RecvError>),
-        Indication(Result<(ModuleId, Indication), broadcast::RecvError>),
     }
 
     let mut events = stream::select(
         rx.map(Event::ClientMessage),
-        stream::select(
-            model_ops.map(Event::ModelOp),
-            indics.map(Event::Indication),
-        ),
+        model_ops.map(Event::ModelOp),
     );
 
     while let Some(event) = events.next().await {
@@ -86,26 +82,16 @@ async fn session(websocket: WebSocket, engine: Arc<EngineHandle>) {
                 println!("{:?}", msg);
                 println!(" => {:?}", engine.update(msg));
             }
-            Event::ModelOp(Err(broadcast::RecvError::Lagged(skipped))) |
-            Event::Indication(Err(broadcast::RecvError::Lagged(skipped))) => {
+            Event::ModelOp(Err(broadcast::RecvError::Lagged(skipped))) => {
                 println!("disconnecting client: lagged {} messages behind", skipped);
                 return;
             }
-            Event::ModelOp(Err(broadcast::RecvError::Closed)) |
-            Event::Indication(Err(broadcast::RecvError::Closed)) => {
+            Event::ModelOp(Err(broadcast::RecvError::Closed)) => {
                 // TODO we should tell the user that the engine has stopped
                 unimplemented!()
             }
             Event::ModelOp(Ok((pos, op))) => {
                 let msg = bincode::serialize(&ServerMessage::ModelOp(pos, op))
-                    .expect("bincode::serialize");
-
-                tx.send(ws::Message::binary(msg))
-                    .await
-                    .expect("tx.send ModelOp")
-            }
-            Event::Indication(Ok((module_id, indic))) => {
-                let msg = bincode::serialize(&ServerMessage::Indication(module_id, indic))
                     .expect("bincode::serialize");
 
                 tx.send(ws::Message::binary(msg))

--- a/src/module/amplifier.rs
+++ b/src/module/amplifier.rs
@@ -1,4 +1,4 @@
-use crate::engine::{Sample, ZERO_BUFFER, ONE_BUFFER};
+use crate::engine::{Sample, ZERO_BUFFER_STEREO, ONE_BUFFER_MONO};
 use crate::module::{Module, LineType};
 
 use mixlab_protocol::AmplifierParams;
@@ -28,8 +28,8 @@ impl Module for Amplifier {
     fn run_tick(&mut self, _t: u64, inputs: &[Option<&[Sample]>], outputs: &mut [&mut [Sample]]) -> Option<Self::Indication> {
         let AmplifierParams {mod_depth, amplitude} = self.params;
 
-        let input = &inputs[0].unwrap_or(&ZERO_BUFFER);
-        let mod_input = &inputs[1].unwrap_or(&ONE_BUFFER);
+        let input = &inputs[0].unwrap_or(&ZERO_BUFFER_STEREO);
+        let mod_input = &inputs[1].unwrap_or(&ONE_BUFFER_MONO);
         let output = &mut outputs[0];
 
         let len = input.len();

--- a/src/module/amplifier.rs
+++ b/src/module/amplifier.rs
@@ -1,5 +1,5 @@
 use crate::engine::{Sample, ZERO_BUFFER, ONE_BUFFER};
-use crate::module::Module;
+use crate::module::{Module, LineType};
 
 use mixlab_protocol::AmplifierParams;
 
@@ -40,12 +40,12 @@ impl Module for Amplifier {
         None
     }
 
-    fn input_count(&self) -> usize {
-        2
+    fn inputs(&self) -> &[LineType] {
+        &[LineType::Stereo, LineType::Stereo]
     }
 
-    fn output_count(&self) -> usize {
-        1
+    fn outputs(&self) -> &[LineType] {
+        &[LineType::Stereo]
     }
 }
 

--- a/src/module/amplifier.rs
+++ b/src/module/amplifier.rs
@@ -27,21 +27,25 @@ impl Module for Amplifier {
 
     fn run_tick(&mut self, _t: u64, inputs: &[Option<&[Sample]>], outputs: &mut [&mut [Sample]]) -> Option<Self::Indication> {
         let AmplifierParams {mod_depth, amplitude} = self.params;
-        let len = outputs[0].len();
 
         let input = &inputs[0].unwrap_or(&ZERO_BUFFER);
         let mod_input = &inputs[1].unwrap_or(&ONE_BUFFER);
         let output = &mut outputs[0];
 
+        let len = input.len();
+
         for i in 0..len {
-            output[i] = input[i] * depth(mod_input[i], mod_depth) * amplitude;
+            // mod input is a mono channel and so half the length:
+            let mod_value = mod_input[i / 2];
+
+            output[i] = input[i] * depth(mod_value, mod_depth) * amplitude;
         }
 
         None
     }
 
     fn inputs(&self) -> &[LineType] {
-        &[LineType::Stereo, LineType::Stereo]
+        &[LineType::Stereo, LineType::Mono]
     }
 
     fn outputs(&self) -> &[LineType] {

--- a/src/module/fm_sine.rs
+++ b/src/module/fm_sine.rs
@@ -2,7 +2,7 @@ use std::f32;
 
 use mixlab_protocol::{FmSineParams, LineType};
 
-use crate::engine::{Sample, SAMPLE_RATE, CHANNELS, ZERO_BUFFER};
+use crate::engine::{Sample, SAMPLE_RATE, CHANNELS, ZERO_BUFFER_STEREO};
 use crate::module::Module;
 
 #[derive(Debug)]
@@ -30,7 +30,7 @@ impl Module for FmSine {
     fn run_tick(&mut self, t: u64, inputs: &[Option<&[Sample]>], outputs: &mut [&mut [Sample]]) -> Option<Self::Indication> {
         let len = outputs[0].len() / CHANNELS;
 
-        let input = inputs[0].unwrap_or(&ZERO_BUFFER);
+        let input = inputs[0].unwrap_or(&ZERO_BUFFER_STEREO);
 
         let freq_amp = (self.params.freq_hi - self.params.freq_lo) / 2.0;
         let freq_mid = self.params.freq_lo + freq_amp;

--- a/src/module/fm_sine.rs
+++ b/src/module/fm_sine.rs
@@ -1,6 +1,6 @@
 use std::f32;
 
-use mixlab_protocol::FmSineParams;
+use mixlab_protocol::{FmSineParams, LineType};
 
 use crate::engine::{Sample, SAMPLE_RATE, CHANNELS, ZERO_BUFFER};
 use crate::module::Module;
@@ -48,11 +48,11 @@ impl Module for FmSine {
         None
     }
 
-    fn input_count(&self) -> usize {
-        1
+    fn inputs(&self) -> &[LineType] {
+        &[LineType::Stereo]
     }
 
-    fn output_count(&self) -> usize {
-        1
+    fn outputs(&self) -> &[LineType] {
+        &[LineType::Stereo]
     }
 }

--- a/src/module/mixer_2ch.rs
+++ b/src/module/mixer_2ch.rs
@@ -1,3 +1,5 @@
+use mixlab_protocol::LineType;
+
 use crate::engine::{Sample, ZERO_BUFFER};
 use crate::module::Module;
 
@@ -33,11 +35,11 @@ impl Module for Mixer2ch {
         None
     }
 
-    fn input_count(&self) -> usize {
-        2
+    fn inputs(&self) -> &[LineType] {
+        &[LineType::Stereo, LineType::Stereo]
     }
 
-    fn output_count(&self) -> usize {
-        1
+    fn outputs(&self) -> &[LineType] {
+        &[LineType::Stereo]
     }
 }

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -3,6 +3,8 @@ pub mod fm_sine;
 pub mod mixer_2ch;
 pub mod output_device;
 pub mod sine_generator;
+pub mod stereo_panner;
+pub mod stereo_splitter;
 pub mod trigger;
 
 use mixlab_protocol::LineType;

--- a/src/module/mod.rs
+++ b/src/module/mod.rs
@@ -5,6 +5,8 @@ pub mod output_device;
 pub mod sine_generator;
 pub mod trigger;
 
+use mixlab_protocol::LineType;
+
 use crate::engine::Sample;
 
 pub trait Module: Sized {
@@ -15,6 +17,6 @@ pub trait Module: Sized {
     fn params(&self) -> Self::Params;
     fn update(&mut self, new_params: Self::Params) -> Option<Self::Indication>;
     fn run_tick(&mut self, t: u64, inputs: &[Option<&[Sample]>], outputs: &mut [&mut [Sample]]) -> Option<Self::Indication>;
-    fn input_count(&self) -> usize;
-    fn output_count(&self) -> usize;
+    fn inputs(&self) -> &[LineType];
+    fn outputs(&self) -> &[LineType];
 }

--- a/src/module/output_device.rs
+++ b/src/module/output_device.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug};
 use cpal::traits::{HostTrait, DeviceTrait, StreamTrait};
 use ringbuf::{RingBuffer, Producer};
 
-use mixlab_protocol::{OutputDeviceParams, OutputDeviceIndication};
+use mixlab_protocol::{OutputDeviceParams, OutputDeviceIndication, LineType};
 
 use crate::engine::{Sample, CHANNELS};
 use crate::module::Module;
@@ -162,11 +162,11 @@ impl Module for OutputDevice {
         None
     }
 
-    fn input_count(&self) -> usize {
-        1
+    fn inputs(&self) -> &[LineType] {
+        &[LineType::Stereo]
     }
 
-    fn output_count(&self) -> usize {
-        0
+    fn outputs(&self) -> &[LineType] {
+        &[]
     }
 }

--- a/src/module/sine_generator.rs
+++ b/src/module/sine_generator.rs
@@ -1,6 +1,6 @@
 use std::f32;
 
-use mixlab_protocol::SineGeneratorParams;
+use mixlab_protocol::{SineGeneratorParams, LineType};
 
 use crate::engine::{Sample, SAMPLE_RATE, CHANNELS};
 use crate::module::Module;
@@ -43,11 +43,11 @@ impl Module for SineGenerator {
         None
     }
 
-    fn input_count(&self) -> usize {
-        0
+    fn inputs(&self) -> &[LineType] {
+        &[]
     }
 
-    fn output_count(&self) -> usize {
-        1
+    fn outputs(&self)-> &[LineType] {
+        &[LineType::Stereo]
     }
 }

--- a/src/module/stereo_panner.rs
+++ b/src/module/stereo_panner.rs
@@ -1,17 +1,15 @@
-use mixlab_protocol::LineType;
-
-use crate::engine::{Sample, ZERO_BUFFER_STEREO};
-use crate::module::Module;
+use crate::engine::{Sample, ZERO_BUFFER_MONO};
+use crate::module::{Module, LineType};
 
 #[derive(Debug)]
-pub struct Mixer2ch;
+pub struct StereoPanner;
 
-impl Module for Mixer2ch {
+impl Module for StereoPanner {
     type Params = ();
     type Indication = ();
 
     fn create(_: Self::Params) -> (Self, Self::Indication) {
-        (Mixer2ch, ())
+        (StereoPanner, ())
     }
 
     fn params(&self) -> Self::Params {
@@ -23,20 +21,20 @@ impl Module for Mixer2ch {
     }
 
     fn run_tick(&mut self, _t: u64, inputs: &[Option<&[Sample]>], outputs: &mut [&mut [Sample]]) -> Option<Self::Indication> {
-        let len = outputs[0].len();
+        let left = &inputs[0].unwrap_or(&ZERO_BUFFER_MONO);
+        let right = &inputs[1].unwrap_or(&ZERO_BUFFER_MONO);
+        let output = &mut outputs[0];
 
-        let input0 = &inputs[0].unwrap_or(&ZERO_BUFFER_STEREO);
-        let input1 = &inputs[1].unwrap_or(&ZERO_BUFFER_STEREO);
-
-        for i in 0..len {
-            outputs[0][i] = input0[i] + input1[i];
+        for i in 0..left.len() {
+            output[i * 2 + 0] = left[i];
+            output[i * 2 + 1] = right[i];
         }
 
         None
     }
 
     fn inputs(&self) -> &[LineType] {
-        &[LineType::Stereo, LineType::Stereo]
+        &[LineType::Mono, LineType::Mono]
     }
 
     fn outputs(&self) -> &[LineType] {

--- a/src/module/stereo_splitter.rs
+++ b/src/module/stereo_splitter.rs
@@ -1,17 +1,15 @@
-use mixlab_protocol::LineType;
-
 use crate::engine::{Sample, ZERO_BUFFER_STEREO};
-use crate::module::Module;
+use crate::module::{Module, LineType};
 
 #[derive(Debug)]
-pub struct Mixer2ch;
+pub struct StereoSplitter;
 
-impl Module for Mixer2ch {
+impl Module for StereoSplitter {
     type Params = ();
     type Indication = ();
 
     fn create(_: Self::Params) -> (Self, Self::Indication) {
-        (Mixer2ch, ())
+        (StereoSplitter, ())
     }
 
     fn params(&self) -> Self::Params {
@@ -23,23 +21,25 @@ impl Module for Mixer2ch {
     }
 
     fn run_tick(&mut self, _t: u64, inputs: &[Option<&[Sample]>], outputs: &mut [&mut [Sample]]) -> Option<Self::Indication> {
-        let len = outputs[0].len();
+        let input = &inputs[0].unwrap_or(&ZERO_BUFFER_STEREO);
 
-        let input0 = &inputs[0].unwrap_or(&ZERO_BUFFER_STEREO);
-        let input1 = &inputs[1].unwrap_or(&ZERO_BUFFER_STEREO);
-
-        for i in 0..len {
-            outputs[0][i] = input0[i] + input1[i];
+        if let [left, right] = outputs {
+            for i in 0..left.len() {
+                left[i] = input[i * 2 + 0];
+                right[i] = input[i * 2 + 1];
+            }
+        } else {
+            unreachable!();
         }
 
         None
     }
 
     fn inputs(&self) -> &[LineType] {
-        &[LineType::Stereo, LineType::Stereo]
+        &[LineType::Stereo]
     }
 
     fn outputs(&self) -> &[LineType] {
-        &[LineType::Stereo]
+        &[LineType::Mono, LineType::Mono]
     }
 }

--- a/src/module/trigger.rs
+++ b/src/module/trigger.rs
@@ -1,4 +1,4 @@
-use mixlab_protocol::GateState;
+use mixlab_protocol::{GateState, LineType};
 
 use crate::engine::Sample;
 use crate::module::Module;
@@ -40,11 +40,11 @@ impl Module for Trigger {
         None
     }
 
-    fn input_count(&self) -> usize {
-        0
+    fn inputs(&self) -> &[LineType] {
+        &[]
     }
 
-    fn output_count(&self) -> usize {
-        1
+    fn outputs(&self) -> &[LineType] {
+        &[LineType::Stereo]
     }
 }

--- a/src/module/trigger.rs
+++ b/src/module/trigger.rs
@@ -45,6 +45,6 @@ impl Module for Trigger {
     }
 
     fn outputs(&self) -> &[LineType] {
-        &[LineType::Stereo]
+        &[LineType::Mono]
     }
 }


### PR DESCRIPTION
Two types currently. Mono and stereo. It looks like this:

![image](https://user-images.githubusercontent.com/179065/78370606-959ffb00-7612-11ea-9079-413cdf09198e.png)

Still to do:

* Should SineGenerator have a mono output? Probably

* Something like Mixer2ch shouldn't care whether its input is mono or stereo, as long as they are consistently one or the other

* Similarly, Amplifier's mod input should always be mono but its line input can be either and it will output the same