### PR TITLE
First pass at making a scroll handling component (wired up to fader and rotary)

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -22,6 +22,7 @@ web-sys = { version = "0.3", features = [
     "CssStyleDeclaration",
     "HtmlCanvasElement",
     "InputEvent",
+    "WheelEvent",
     "WebSocket",
     ] }
 

--- a/frontend/src/component/mod.rs
+++ b/frontend/src/component/mod.rs
@@ -1,1 +1,2 @@
 pub mod drag_target;
+pub mod scroll_target;

--- a/frontend/src/component/scroll_target.rs
+++ b/frontend/src/component/scroll_target.rs
@@ -1,0 +1,97 @@
+use gloo_events::{EventListener, EventListenerOptions};
+use wasm_bindgen::JsCast;
+use web_sys::{WheelEvent, Element};
+use yew::{html, Component, ComponentLink, Html, ShouldRender, Properties, NodeRef, Children, Callback, Renderable};
+
+#[derive(Properties, Clone)]
+pub struct ScrollProps {
+    #[prop_or_default]
+    pub on_scroll: Option<Callback<Scroll>>,
+
+    #[prop_or_default]
+    pub children: Children,
+}
+
+#[derive(Debug, Clone)]
+pub enum Scroll {
+    Up(f64),
+    Down(f64),
+}
+
+pub struct ScrollTarget {
+    link: ComponentLink<Self>,
+    props: ScrollProps,
+    container: NodeRef,
+    // state: Option<ScrollState>,
+}
+
+impl Component for ScrollTarget {
+    type Properties = ScrollProps;
+    type Message = ();
+
+    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        ScrollTarget {
+            link,
+            props,
+            container: NodeRef::default(),
+        }
+    }
+
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.props = props;
+        true
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        crate::log!("{:?}", msg);
+        false
+    }
+
+    // yew doesn't know about `onwheel` and tries to call `to_string()`, so
+    // attaching event handler manually.
+    fn mounted(&mut self) -> ShouldRender {
+        if let Some(el) = self.container.cast::<Element>() {
+            let options = EventListenerOptions::enable_prevent_default();
+            let wheel = EventListener::new_with_options(
+                &el, "wheel", options,
+                {
+                    let on_scroll = self.props.on_scroll.clone();
+                    move |ev| {
+                        if let Some(on_scroll) = &on_scroll {
+                            if let Some(ev) = ev.dyn_ref::<WheelEvent>().cloned() {
+                                let delta = ev.delta_y();
+
+                                let scroll = if delta < 0.0 {
+                                    Scroll::Up(delta.abs())
+                                } else {
+                                    Scroll::Down(delta.abs())
+                                };
+
+                                ev.prevent_default();
+                                ev.stop_propagation();
+                                on_scroll.emit(scroll);
+                            }
+                        }
+                    }
+                }
+            );
+
+            // TODO: maybe store this in the state. Unclear when this is dropped
+            // if forgotten.
+            wheel.forget();
+        }
+
+        false
+    }
+
+    fn view(&self) -> Html {
+        html! {
+            <div
+                class="scroll-target-container"
+                ref={self.container.clone()}
+            >
+                {self.props.children.render()}
+            </div>
+        }
+    }
+}

--- a/frontend/src/component/scroll_target.rs
+++ b/frontend/src/component/scroll_target.rs
@@ -23,7 +23,6 @@ struct State {
 }
 
 pub struct ScrollTarget {
-    link: ComponentLink<Self>,
     props: ScrollProps,
     container: NodeRef,
     state: State,
@@ -33,9 +32,8 @@ impl Component for ScrollTarget {
     type Properties = ScrollProps;
     type Message = ();
 
-    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
         ScrollTarget {
-            link,
             props,
             container: NodeRef::default(),
             state: State { wheel_listener: None }

--- a/frontend/src/component/scroll_target.rs
+++ b/frontend/src/component/scroll_target.rs
@@ -18,11 +18,15 @@ pub enum Scroll {
     Down(f64),
 }
 
+struct State {
+    pub wheel_listener: Option<EventListener>,
+}
+
 pub struct ScrollTarget {
     link: ComponentLink<Self>,
     props: ScrollProps,
     container: NodeRef,
-    // state: Option<ScrollState>,
+    state: State,
 }
 
 impl Component for ScrollTarget {
@@ -34,6 +38,7 @@ impl Component for ScrollTarget {
             link,
             props,
             container: NodeRef::default(),
+            state: State { wheel_listener: None }
         }
     }
 
@@ -76,9 +81,7 @@ impl Component for ScrollTarget {
                 }
             );
 
-            // TODO: maybe store this in the state. Unclear when this is dropped
-            // if forgotten.
-            wheel.forget();
+            self.state.wheel_listener = Some(wheel);
         }
 
         false


### PR DESCRIPTION
Many open questions:

* Delta direction may vary based on "natural scroll" setting in OS?
* Does it work on trackpads or do we need to use `scroll` event instead?
* There are different delta modes (pixels vs lines etc)
* Actual delta seems fixed in increments of 100 but this may be specific
  to my OS / browser
* I am putting the direction in their own enum variant (instead of
  negative) but given we have to use a negative number later, this might
  not be useful.
* There are other event attributes that web_sys doesn't expose which may
  have more complete data for making sure the way we interpret scroll
  deltas is more normalised.

Ideally, we could detect the minimum scroll increment and pass a single
Up/Down scroll increment internally. Right now I'm passing 100 or -100 to the
fader and then scaling that down by 0.001 but that doesn't feel right.

![1961f3f6-4b9e-4d0e-9f5d-e062e64bfb6c](https://user-images.githubusercontent.com/2560/78656920-6be51d80-790b-11ea-840f-7f0db92386c3.gif)
