### PR TITLE
Add client sequence to ClientMessage

### DIFF
--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -17,15 +17,17 @@ use yew::format::Binary;
 use yew::services::websocket::{WebSocketService, WebSocketStatus, WebSocketTask};
 use yew::{html, Component, ComponentLink, Html, ShouldRender};
 
-use mixlab_protocol::{ClientMessage, WorkspaceState, ServerMessage, ModuleId, InputId, OutputId, ModuleParams, WindowGeometry, ModelOp, Indication, Terminal};
+use mixlab_protocol::{ClientMessage, WorkspaceState, ServerMessage, ModuleId, InputId, OutputId, ModuleParams, WindowGeometry, ModelOp, Indication, Terminal, ClientOp, ClientSequence};
 
+use util::Sequence;
 use workspace::Workspace;
 
 pub struct App {
     link: ComponentLink<Self>,
     websocket: WebSocketTask,
     state: Option<Rc<RefCell<State>>>,
-    state_seq: usize,
+    client_seq: Sequence,
+    server_seq: Option<ClientSequence>,
     root_element: Element,
     viewport_width: usize,
     viewport_height: usize,
@@ -62,7 +64,7 @@ pub enum AppMsg {
     NoOp,
     WindowResize,
     ServerMessage(ServerMessage),
-    ClientUpdate(ClientMessage),
+    ClientUpdate(ClientOp),
 }
 
 impl Component for App {
@@ -112,7 +114,8 @@ impl Component for App {
             link,
             websocket,
             state: None,
-            state_seq: 0,
+            client_seq: Sequence::new(),
+            server_seq: None,
             root_element,
             viewport_width,
             viewport_height,
@@ -134,7 +137,7 @@ impl Component for App {
                         self.state = Some(Rc::new(RefCell::new(state.into())));
                         true
                     }
-                    ServerMessage::ModelOp(_, op) => {
+                    ServerMessage::ModelOp(seq, op) => {
                         let mut state = self.state.as_ref()
                             .expect("server should always send a WorkspaceState before a ModelOp")
                             .borrow_mut();
@@ -177,12 +180,38 @@ impl Component for App {
                             }
                         }
 
-                        self.state_seq += 1;
-                        true
+                        // only re-render according to server state if all of
+                        // our changes have successfully round-tripped
+                        if let Some(seq) = seq {
+                            if Some(seq) <= self.server_seq {
+                                panic!("sequence number repeat, desync");
+                            }
+
+                            self.server_seq = Some(seq);
+                        }
+
+                        let client_seq = self.client_seq.last().map(ClientSequence);
+
+                        log!("server_seq: {:?}, client_seq: {:?}", self.server_seq, client_seq);
+
+                        if self.server_seq == client_seq {
+                            // server is up to date, re-render
+                            true
+                        } else if self.server_seq < client_seq {
+                            // server is behind, skip render
+                            false
+                        } else {
+                            panic!("server_seq > client_seq, desync")
+                        }
                     }
                 }
             }
-            AppMsg::ClientUpdate(msg) => {
+            AppMsg::ClientUpdate(op) => {
+                let msg = ClientMessage {
+                    sequence: ClientSequence(self.client_seq.next()),
+                    op: op,
+                };
+
                 let packet = bincode::serialize(&msg)
                     .expect("bincode::serialize");
 
@@ -200,7 +229,6 @@ impl Component for App {
                     <Workspace
                         app={self.link.clone()}
                         state={state}
-                        state_seq={self.state_seq}
                         width={self.viewport_width}
                         height={self.viewport_height}
                     />

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -192,8 +192,6 @@ impl Component for App {
 
                         let client_seq = self.client_seq.last().map(ClientSequence);
 
-                        log!("server_seq: {:?}, client_seq: {:?}", self.server_seq, client_seq);
-
                         if self.server_seq == client_seq {
                             // server is up to date, re-render
                             true

--- a/frontend/src/util.rs
+++ b/frontend/src/util.rs
@@ -43,3 +43,26 @@ pub fn clamp<T: PartialOrd>(min: T, max: T, val: T) -> T {
         val
     }
 }
+
+pub struct Sequence(usize);
+
+impl Sequence {
+    pub fn new() -> Self {
+        Sequence(0)
+    }
+
+    /// Returns the last sequence number generated:
+    pub fn last(&self) -> Option<usize> {
+        if self.0 == 0 {
+            None
+        } else {
+            Some(self.0)
+        }
+    }
+
+    /// Generates a new sequence number
+    pub fn next(&mut self) -> usize {
+        self.0 += 1;
+        self.0
+    }
+}

--- a/frontend/src/util.rs
+++ b/frontend/src/util.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use yew::{Component, ComponentLink, Callback};
 use web_sys::Event;
 
@@ -52,17 +54,13 @@ impl Sequence {
     }
 
     /// Returns the last sequence number generated:
-    pub fn last(&self) -> Option<usize> {
-        if self.0 == 0 {
-            None
-        } else {
-            Some(self.0)
-        }
+    pub fn last(&self) -> Option<NonZeroUsize> {
+        NonZeroUsize::new(self.0)
     }
 
     /// Generates a new sequence number
-    pub fn next(&mut self) -> usize {
+    pub fn next(&mut self) -> NonZeroUsize {
         self.0 += 1;
-        self.0
+        NonZeroUsize::new(self.0).unwrap()
     }
 }

--- a/frontend/src/workspace.rs
+++ b/frontend/src/workspace.rs
@@ -18,27 +18,13 @@ use crate::module::output_device::OutputDevice;
 use crate::module::plotter::Plotter;
 use crate::module::sine_generator::SineGenerator;
 use crate::module::trigger::Trigger;
-use crate::util::{callback_ex, stop_propagation, prevent_default};
+use crate::util::{callback_ex, stop_propagation, prevent_default, Sequence};
 use crate::{App, AppMsg, State};
-
-pub struct Counter(usize);
-
-impl Counter {
-    pub fn new() -> Self {
-        Counter(0)
-    }
-
-    pub fn next(&mut self) -> usize {
-        let seq = self.0;
-        self.0 += 1;
-        seq
-    }
-}
 
 pub struct Workspace {
     link: ComponentLink<Self>,
     props: WorkspaceProps,
-    gen_z_index: Counter,
+    gen_z_index: Sequence,
     mouse: MouseMode,
     window_refs: BTreeMap<ModuleId, WindowRef>,
 }
@@ -87,7 +73,7 @@ impl Component for Workspace {
         let mut workspace = Workspace {
             link,
             props,
-            gen_z_index: Counter::new(),
+            gen_z_index: Sequence::new(),
             mouse: MouseMode::Normal,
             window_refs: BTreeMap::new(),
         };

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -8,7 +8,8 @@ pub type Sample = f32;
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ServerMessage {
     WorkspaceState(WorkspaceState),
-    ModelOp(Option<ClientSequence>, ModelOp),
+    Update(ServerUpdate),
+    Sync(ClientSequence),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -41,7 +42,7 @@ pub enum ClientOp {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum ModelOp {
+pub enum ServerUpdate {
     CreateModule {
         id: ModuleId,
         params: ModuleParams,

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::num::NonZeroUsize;
 
 use serde_derive::{Deserialize, Serialize};
 
@@ -52,7 +53,7 @@ pub enum ModelOp {
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct ModuleId(pub usize);
+pub struct ModuleId(pub NonZeroUsize);
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub enum TerminalId {

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -8,7 +8,7 @@ pub type Sample = f32;
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ServerMessage {
     WorkspaceState(WorkspaceState),
-    ModelOp(LogPosition, ModelOp),
+    ModelOp(Option<ClientSequence>, ModelOp),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -22,7 +22,16 @@ pub struct WorkspaceState {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub enum ClientMessage {
+pub struct ClientMessage {
+    pub sequence: ClientSequence,
+    pub op: ClientOp,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ClientSequence(pub NonZeroUsize);
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum ClientOp {
     CreateModule(ModuleParams, WindowGeometry),
     UpdateModuleParams(ModuleId, ModuleParams),
     UpdateWindowGeometry(ModuleId, WindowGeometry),
@@ -30,9 +39,6 @@ pub enum ClientMessage {
     CreateConnection(InputId, OutputId),
     DeleteConnection(InputId),
 }
-
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
-pub struct LogPosition(pub usize);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ModelOp {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,4 @@
-use crate::module::Module;
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::f32;
 use std::num::NonZeroUsize;
@@ -8,11 +8,30 @@ use std::time::{Instant, Duration};
 
 use tokio::sync::{oneshot, broadcast};
 
-use mixlab_protocol::{ModuleId, InputId, OutputId, ClientMessage, TerminalId, WorkspaceState, WindowGeometry, ModelOp, LogPosition, Indication, LineType};
+use mixlab_protocol::{ModuleId, InputId, OutputId, ClientMessage, TerminalId, WorkspaceState, WindowGeometry, ModelOp, Indication, LineType, ClientSequence, ClientOp};
 
+use crate::module::Module;
 use crate::util::Sequence;
 
 pub type Sample = f32;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SessionId(NonZeroUsize);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+// NOTE! This is not Ord because log positions with different session IDs have
+// no relative ordering
+pub struct OpClock(pub SessionId, pub ClientSequence);
+
+impl PartialOrd for OpClock {
+    fn partial_cmp(&self, other: &OpClock) -> Option<Ordering> {
+        if self.0 == other.0 {
+            Some(self.1.cmp(&other.1))
+        } else {
+            None
+        }
+    }
+}
 
 pub const CHANNELS: usize = 2;
 pub const SAMPLE_RATE: usize = 44100;
@@ -25,8 +44,8 @@ pub static ZERO_BUFFER_MONO: [Sample; SAMPLES_PER_TICK] = [0.0; SAMPLES_PER_TICK
 pub static ONE_BUFFER_MONO: [Sample; SAMPLES_PER_TICK] = [1.0; SAMPLES_PER_TICK];
 
 pub enum EngineMessage {
-    ConnectSession(oneshot::Sender<(WorkspaceState, EngineOps)>),
-    ClientMessage(ClientMessage),
+    ConnectSession(oneshot::Sender<(SessionId, WorkspaceState, EngineOps)>),
+    ClientMessage(SessionId, ClientMessage),
 }
 
 pub struct EngineHandle {
@@ -34,6 +53,7 @@ pub struct EngineHandle {
 }
 
 pub struct EngineSession {
+    session_id: SessionId,
     cmd_tx: SyncSender<EngineMessage>,
 }
 
@@ -45,7 +65,7 @@ pub fn start() -> EngineHandle {
         let mut engine = Engine {
             cmd_rx,
             log_tx,
-            log_seq: Sequence::new(),
+            session_seq: Sequence::new(),
             modules: HashMap::new(),
             geometry: HashMap::new(),
             module_seq: Sequence::new(),
@@ -74,7 +94,7 @@ impl<T> From<TrySendError<T>> for EngineError {
     }
 }
 
-pub type EngineOps = broadcast::Receiver<(LogPosition, ModelOp)>;
+pub type EngineOps = broadcast::Receiver<(Option<OpClock>, ModelOp)>;
 
 impl EngineHandle {
     pub async fn connect(&self) -> Result<(WorkspaceState, EngineOps, EngineSession), EngineError> {
@@ -82,16 +102,23 @@ impl EngineHandle {
 
         let (tx, rx) = oneshot::channel();
         cmd_tx.try_send(EngineMessage::ConnectSession(tx))?;
-        let (state, log_rx) = rx.await.map_err(|_| EngineError::Stopped)?;
+        let (session_id, state, log_rx) = rx.await.map_err(|_| EngineError::Stopped)?;
 
-        Ok((state, log_rx, EngineSession { cmd_tx }))
+        Ok((state, log_rx, EngineSession {
+            cmd_tx,
+            session_id,
+        }))
     }
 }
 
 impl EngineSession {
+    pub fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+
     /// TODO - maybe pass log position in here and detect conflicts?
     pub fn update(&self, msg: ClientMessage) -> Result<(), EngineError> {
-        self.send_message(EngineMessage::ClientMessage(msg))
+        self.send_message(EngineMessage::ClientMessage(self.session_id, msg))
     }
 
     fn send_message(&self, msg: EngineMessage) -> Result<(), EngineError> {
@@ -101,8 +128,8 @@ impl EngineSession {
 
 pub struct Engine {
     cmd_rx: Receiver<EngineMessage>,
-    log_tx: broadcast::Sender<(LogPosition, ModelOp)>,
-    log_seq: Sequence,
+    log_tx: broadcast::Sender<(Option<OpClock>, ModelOp)>,
+    session_seq: Sequence,
     modules: HashMap<ModuleId, Module>,
     geometry: HashMap<ModuleId, WindowGeometry>,
     module_seq: Sequence,
@@ -121,7 +148,7 @@ impl Engine {
 
             for (module_id, indication) in indications {
                 self.indications.insert(module_id, indication.clone());
-                self.log_op(ModelOp::UpdateModuleIndication(module_id, indication));
+                self.log_op(None, ModelOp::UpdateModuleIndication(module_id, indication));
             }
 
             let sleep_until = start + Duration::from_millis(tick * 1_000 / TICKS_PER_SECOND as u64);
@@ -135,7 +162,7 @@ impl Engine {
 
                 match self.cmd_rx.recv_timeout(sleep_until - now) {
                     Ok(EngineMessage::ConnectSession(tx)) => { let _ = tx.send(self.connect_session()); }
-                    Ok(EngineMessage::ClientMessage(msg)) => { self.client_update(msg); }
+                    Ok(EngineMessage::ClientMessage(session, msg)) => { self.client_update(session, msg); }
                     Err(RecvTimeoutError::Timeout) => { break; }
                     Err(RecvTimeoutError::Disconnected) => { return; }
                 }
@@ -143,10 +170,11 @@ impl Engine {
         }
     }
 
-    fn connect_session(&mut self) -> (WorkspaceState, EngineOps) {
+    fn connect_session(&mut self) -> (SessionId, WorkspaceState, EngineOps) {
+        let session_id = SessionId(self.session_seq.next());
         let log_rx = self.log_tx.subscribe();
         let state = self.dump_state();
-        (state, log_rx)
+        (session_id, state, log_rx)
     }
 
     fn dump_state(&self) -> WorkspaceState {
@@ -180,14 +208,15 @@ impl Engine {
         state
     }
 
-    fn log_op(&mut self, op: ModelOp) {
-        let pos = LogPosition(self.log_seq.next());
-        let _ = self.log_tx.send((pos, op));
+    fn log_op(&mut self, clock: Option<OpClock>, op: ModelOp) {
+        let _ = self.log_tx.send((clock, op));
     }
 
-    fn client_update(&mut self, msg: ClientMessage) {
-        match msg {
-            ClientMessage::CreateModule(params, geometry) => {
+    fn client_update(&mut self, session_id: SessionId, msg: ClientMessage) {
+        let clock = Some(OpClock(session_id, msg.sequence));
+
+        match msg.op {
+            ClientOp::CreateModule(params, geometry) => {
                 // TODO - the audio engine is not actually concerned with
                 // window geometry and so should not own this data and force
                 // all accesses to it to go via the live audio thread
@@ -199,7 +228,7 @@ impl Engine {
                 self.geometry.insert(id, geometry.clone());
                 self.indications.insert(id, indication.clone());
 
-                self.log_op(ModelOp::CreateModule {
+                self.log_op(clock, ModelOp::CreateModule {
                     id,
                     params,
                     geometry,
@@ -208,19 +237,19 @@ impl Engine {
                     outputs,
                 });
             }
-            ClientMessage::UpdateModuleParams(module_id, params) => {
+            ClientOp::UpdateModuleParams(module_id, params) => {
                 if let Some(module) = self.modules.get_mut(&module_id) {
                     module.update(params.clone());
-                    self.log_op(ModelOp::UpdateModuleParams(module_id, params));
+                    self.log_op(clock, ModelOp::UpdateModuleParams(module_id, params));
                 }
             }
-            ClientMessage::UpdateWindowGeometry(module_id, geometry) => {
+            ClientOp::UpdateWindowGeometry(module_id, geometry) => {
                 if let Some(geom) = self.geometry.get_mut(&module_id) {
                     *geom = geometry.clone();
-                    self.log_op(ModelOp::UpdateWindowGeometry(module_id, geometry));
+                    self.log_op(clock, ModelOp::UpdateWindowGeometry(module_id, geometry));
                 }
             }
-            ClientMessage::DeleteModule(module_id) => {
+            ClientOp::DeleteModule(module_id) => {
                 // find any connections connected to this module's inputs or
                 // outputs and delete them, generating oplog entries
 
@@ -234,17 +263,17 @@ impl Engine {
 
                 for deleted_connection in deleted_connections {
                     self.connections.remove(&deleted_connection);
-                    self.log_op(ModelOp::DeleteConnection(deleted_connection));
+                    self.log_op(clock, ModelOp::DeleteConnection(deleted_connection));
                 }
 
                 // finally, delete the module:
 
                 if self.modules.contains_key(&module_id) {
                     self.modules.remove(&module_id);
-                    self.log_op(ModelOp::DeleteModule(module_id));
+                    self.log_op(clock, ModelOp::DeleteModule(module_id));
                 }
             }
-            ClientMessage::CreateConnection(input_id, output_id) => {
+            ClientOp::CreateConnection(input_id, output_id) => {
                 let input_type = match terminal_line_type(self, TerminalId::Input(input_id)) {
                     Some(ty) => ty,
                     None => return,
@@ -257,17 +286,17 @@ impl Engine {
 
                 if input_type == output_type {
                     if let Some(_) = self.connections.insert(input_id, output_id) {
-                        self.log_op(ModelOp::DeleteConnection(input_id));
+                        self.log_op(clock, ModelOp::DeleteConnection(input_id));
                     }
 
-                    self.log_op(ModelOp::CreateConnection(input_id, output_id));
+                    self.log_op(clock, ModelOp::CreateConnection(input_id, output_id));
                 } else {
                     // type mismatch, don't connect
                 }
             }
-            ClientMessage::DeleteConnection(input_id) => {
+            ClientOp::DeleteConnection(input_id) => {
                 if let Some(_) = self.connections.remove(&input_id) {
-                    self.log_op(ModelOp::DeleteConnection(input_id));
+                    self.log_op(clock, ModelOp::DeleteConnection(input_id));
                 }
             }
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,6 +1,7 @@
 use crate::module::Module;
 use std::collections::{HashMap, HashSet};
 use std::f32;
+use std::num::NonZeroUsize;
 use std::sync::mpsc::{self, SyncSender, Receiver, RecvTimeoutError, TrySendError};
 use std::thread;
 use std::time::{Instant, Duration};

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,10 +16,10 @@ use warp::Filter;
 use warp::reply::{self, Reply};
 use warp::ws::{self, Ws, WebSocket};
 
-use engine::{EngineHandle, OpClock};
+use engine::{EngineHandle, EngineOp};
 use icecast::http::Disambiguation;
 
-use mixlab_protocol::{ClientMessage, ServerMessage, ModelOp};
+use mixlab_protocol::{ClientMessage, ServerMessage};
 
 fn content(content_type: &str, reply: impl Reply) -> impl Reply {
     reply::with_header(reply, "content-type", content_type)
@@ -64,7 +64,7 @@ fn wasm() -> impl Reply {
 async fn session(websocket: WebSocket, engine: Arc<EngineHandle>) {
     let (mut tx, rx) = websocket.split();
 
-    let (state, model_ops, engine) = engine.connect().await
+    let (state, engine_ops, engine) = engine.connect().await
         .expect("engine.connect");
 
     let state_msg = bincode::serialize(&ServerMessage::WorkspaceState(state))
@@ -76,12 +76,12 @@ async fn session(websocket: WebSocket, engine: Arc<EngineHandle>) {
 
     enum Event {
         ClientMessage(Result<ws::Message, warp::Error>),
-        ModelOp(Result<(Option<OpClock>, ModelOp), broadcast::RecvError>),
+        EngineOp(Result<EngineOp, broadcast::RecvError>),
     }
 
     let mut events = stream::select(
         rx.map(Event::ClientMessage),
-        model_ops.map(Event::ModelOp),
+        engine_ops.map(Event::EngineOp),
     );
 
     while let Some(event) = events.next().await {
@@ -102,32 +102,37 @@ async fn session(websocket: WebSocket, engine: Arc<EngineHandle>) {
                 let result = engine.update(msg);
                 println!(" => {:?}", result);
             }
-            Event::ModelOp(Err(broadcast::RecvError::Lagged(skipped))) => {
+            Event::EngineOp(Err(broadcast::RecvError::Lagged(skipped))) => {
                 println!("disconnecting client: lagged {} messages behind", skipped);
                 return;
             }
-            Event::ModelOp(Err(broadcast::RecvError::Closed)) => {
+            Event::EngineOp(Err(broadcast::RecvError::Closed)) => {
                 // TODO we should tell the user that the engine has stopped
                 unimplemented!()
             }
-            Event::ModelOp(Ok((clock, op))) => {
+            Event::EngineOp(Ok(op)) => {
                 // sequence is only applicable if it belongs to this session:
-                let client_seq = clock.and_then(|clock| {
-                    if clock.0 == engine.session_id() {
-                        Some(clock.1)
-                    } else {
-                        None
+                let msg = match op {
+                    EngineOp::ServerUpdate(update) => Some(ServerMessage::Update(update)),
+                    EngineOp::Sync(clock) => {
+                        if clock.0 == engine.session_id() {
+                            Some(ServerMessage::Sync(clock.1))
+                        } else {
+                            None
+                        }
                     }
-                });
+                };
 
-                let msg = bincode::serialize(&ServerMessage::ModelOp(client_seq, op))
-                    .expect("bincode::serialize");
+                if let Some(msg) = msg {
+                    let msg = bincode::serialize(&msg)
+                        .expect("bincode::serialize");
 
-                match tx.send(ws::Message::binary(msg)).await {
-                    Ok(()) => {}
-                    Err(_) => {
-                        // client disconnected
-                        return;
+                    match tx.send(ws::Message::binary(msg)).await {
+                        Ok(()) => {}
+                        Err(_) => {
+                            // client disconnected
+                            return;
+                        }
                     }
                 }
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,9 +6,8 @@ impl Sequence {
     }
 
     pub fn next(&mut self) -> usize {
-        let seq = self.0;
         self.0 += 1;
-        seq
+        self.0
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 pub struct Sequence(usize);
 
 impl Sequence {
@@ -5,9 +7,9 @@ impl Sequence {
         Sequence(0)
     }
 
-    pub fn next(&mut self) -> usize {
+    pub fn next(&mut self) -> NonZeroUsize {
         self.0 += 1;
-        self.0
+        NonZeroUsize::new(self.0).unwrap()
     }
 }
 


### PR DESCRIPTION
It is now the responsibility of the client to send a sequence number with every message it sends to the server.

When the server broadcasts model updates to clients, it will include the relevant sequence number for the client responsible.

The client uses these sequence numbers to determine whether the server state is up to date with local state, and avoids re-rendering the workspace until the server has caught up.