### PR TITLE
Add WebMIDI support

### DIFF
--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -87,9 +87,12 @@ dependencies = [
  "bincode",
  "console_error_panic_hook",
  "gloo-events",
+ "js-sys",
+ "lazy_static",
  "mixlab-protocol",
  "plotters",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "yew",
 ]

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -75,6 +75,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +97,7 @@ version = "0.0.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",
+ "derive_more",
  "gloo-events",
  "js-sys",
  "lazy_static",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -27,6 +27,7 @@ web-sys = { version = "0.3", features = [
     "HtmlCanvasElement",
     "InputEvent",
     "MidiAccess",
+    "MidiConnectionEvent",
     "MidiInput",
     "MidiInputMap",
     "MidiMessageEvent",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
+derive_more = "0.99"
 bincode = "1.2"
 gloo-events = "0.1"
 js-sys = "0.3"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -13,8 +13,11 @@ default = ["console_error_panic_hook"]
 [dependencies]
 bincode = "1.2"
 gloo-events = "0.1"
+js-sys = "0.3"
+lazy_static = "1.4"
 mixlab-protocol = { path = "../protocol" }
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 yew = { version = "0.14", features = ["web_sys"] }
 
 web-sys = { version = "0.3", features = [
@@ -22,8 +25,14 @@ web-sys = { version = "0.3", features = [
     "CssStyleDeclaration",
     "HtmlCanvasElement",
     "InputEvent",
-    "WheelEvent",
+    "MidiAccess",
+    "MidiInput",
+    "MidiInputMap",
+    "MidiMessageEvent",
+    "MidiPort",
+    "Navigator",
     "WebSocket",
+    "WheelEvent",
     ] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/frontend/src/component/midi_target.rs
+++ b/frontend/src/component/midi_target.rs
@@ -1,0 +1,123 @@
+use web_sys::MouseEvent;
+use yew::{html, Component, ComponentLink, Html, ShouldRender, Properties, Callback, Children, Renderable};
+
+use crate::service::midi::{self, RangeSubscription};
+
+pub struct MidiRangeTarget {
+    link: ComponentLink<Self>,
+    props: MidiTargetProps,
+    state: MidiState,
+}
+
+pub enum MidiState {
+    Unbound,
+    Configure,
+    Bound(RangeSubscription),
+}
+
+#[derive(Properties, Clone)]
+pub struct MidiTargetProps {
+    pub onchange: Callback<f64>,
+    #[prop_or_default]
+    pub children: Children,
+}
+
+pub enum MidiTargetMsg {
+    Configure,
+    Unbind,
+    Bind(RangeSubscription),
+}
+
+impl Component for MidiRangeTarget {
+    type Properties = MidiTargetProps;
+    type Message = MidiTargetMsg;
+
+    fn create(props: MidiTargetProps, link: ComponentLink<Self>) -> Self {
+        MidiRangeTarget {
+            props,
+            link,
+            state: MidiState::Unbound,
+        }
+    }
+
+    fn change(&mut self, props: MidiTargetProps) -> ShouldRender {
+        self.props = props;
+        true
+    }
+
+    fn update(&mut self, msg: MidiTargetMsg) -> ShouldRender {
+        match msg {
+            MidiTargetMsg::Configure => {
+                self.state = MidiState::Configure;
+
+                midi::broker().configure_range({
+                    let link = self.link.clone();
+                    let onchange = self.props.onchange.clone();
+                    Callback::from(move |result| {
+                        match result {
+                            Some((range_id, value)) => {
+                                onchange.emit(value as f64 / 127.0);
+
+                                let subscription = midi::broker().subscribe_range(range_id, {
+                                    let onchange = onchange.clone();
+                                    Callback::from(move |value| {
+                                        onchange.emit(value as f64 / 127.0);
+                                    })
+                                });
+
+                                link.send_message(MidiTargetMsg::Bind(subscription));
+                            }
+                            None => {
+                                link.send_message(MidiTargetMsg::Unbind);
+                            }
+                        }
+                    })
+                });
+                true
+            }
+            MidiTargetMsg::Bind(subscription) => {
+                self.state = MidiState::Bound(subscription);
+                true
+            }
+            MidiTargetMsg::Unbind => {
+                self.state = MidiState::Unbound;
+                true
+            }
+        }
+    }
+
+    fn view(&self) -> Html {
+        let overlay_class = match self.state {
+            MidiState::Unbound => "midi-target-overlay midi-target-overlay-unbound",
+            MidiState::Configure => "midi-target-overlay midi-target-overlay-configure",
+            MidiState::Bound(_) => "midi-target-overlay midi-target-overlay-bound",
+        };
+
+        html! {
+            <div class="midi-target">
+                <div
+                    class={overlay_class}
+                    onmousedown={self.overlay_mousedown()}
+                ></div>
+                {self.props.children.render()}
+            </div>
+        }
+    }
+}
+
+impl MidiRangeTarget {
+    fn overlay_mousedown(&self) -> Callback<MouseEvent> {
+        let link = self.link.clone();
+
+        Callback::from(move |ev: MouseEvent| {
+            ev.stop_propagation();
+
+            if ev.buttons() == 2 {
+                ev.prevent_default();
+                link.send_message(MidiTargetMsg::Unbind);
+            } else {
+                link.send_message(MidiTargetMsg::Configure);
+            }
+        })
+    }
+}

--- a/frontend/src/component/midi_target.rs
+++ b/frontend/src/component/midi_target.rs
@@ -93,12 +93,20 @@ impl Component for MidiRangeTarget {
             MidiState::Bound(_) => "midi-target-overlay midi-target-overlay-bound",
         };
 
+        let overlay_label = if let MidiState::Bound(_) = self.state {
+            html! { <span class="midi-target-overlay-label">{"MIDI"}</span> }
+        } else {
+            html! {}
+        };
+
         html! {
             <div class="midi-target">
                 <div
                     class={overlay_class}
                     onmousedown={self.overlay_mousedown()}
-                ></div>
+                >
+                    {overlay_label}
+                </div>
                 {self.props.children.render()}
             </div>
         }

--- a/frontend/src/component/mod.rs
+++ b/frontend/src/component/mod.rs
@@ -1,3 +1,4 @@
 pub mod drag_target;
+pub mod midi_target;
 pub mod pure_module;
 pub mod scroll_target;

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -265,9 +265,25 @@ extern "C" {
 
     #[wasm_bindgen(js_namespace = console, js_name = log)]
     fn log_val(v: &wasm_bindgen::JsValue);
+
+    #[wasm_bindgen(js_namespace = console, js_name = warn)]
+    fn warn_str(s: &str);
+
+    #[wasm_bindgen(js_namespace = console, js_name = warn)]
+    fn error_str(s: &str);
 }
 
 #[macro_export]
 macro_rules! log {
     ($($t:tt)*) => (crate::log_str(&format_args!($($t)*).to_string()))
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($t:tt)*) => (crate::warn_str(&format_args!($($t)*).to_string()))
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($t:tt)*) => (crate::error_str(&format_args!($($t)*).to_string()))
 }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -3,6 +3,7 @@
 mod component;
 mod control;
 mod module;
+mod service;
 mod util;
 mod workspace;
 

--- a/frontend/src/module/mixer.rs
+++ b/frontend/src/module/mixer.rs
@@ -2,7 +2,7 @@ use yew::{html, Component, ComponentLink, Html, ShouldRender, Properties, Callba
 
 use mixlab_protocol::{ModuleId, MixerParams, MixerChannelParams, ModuleParams, Decibel};
 
-use crate::component::midi_target::MidiRangeTarget;
+use crate::component::midi_target::{MidiRangeTarget, MidiUiMode};
 use crate::control::{Fader, Rotary};
 use crate::workspace::{Window, WindowMsg};
 
@@ -16,6 +16,7 @@ pub struct MixerProps {
     pub id: ModuleId,
     pub module: ComponentLink<Window>,
     pub params: MixerParams,
+    pub midi_mode: MidiUiMode,
 }
 
 pub enum MixerMsg {
@@ -59,6 +60,7 @@ impl Component for Mixer {
                                 params={channel}
                                 onchange={self.link.callback(move |params|
                                     MixerMsg::ChannelChanged(idx, params))}
+                                midi_mode={self.props.midi_mode}
                             />
                         }
                     })
@@ -83,6 +85,7 @@ pub enum ChannelMsg {
 pub struct ChannelProps {
     pub params: MixerChannelParams,
     pub onchange: Callback<MixerChannelParams>,
+    pub midi_mode: MidiUiMode,
 }
 
 impl Component for Channel {
@@ -135,6 +138,7 @@ impl Component for Channel {
         html! {
             <div class="mixer-channel">
                 <MidiRangeTarget
+                    ui_mode={self.props.midi_mode}
                     onchange={self.link.callback(|gain| {
                         ChannelMsg::GainChanged(Decibel(gain * 30.0 - 24.0))
                     })}
@@ -150,7 +154,10 @@ impl Component for Channel {
                 <div class={cue_style} onclick={self.link.callback(|_| ChannelMsg::CueClick)}>
                     {"CUE"}
                 </div>
-                <MidiRangeTarget onchange={self.link.callback(ChannelMsg::FaderChanged)}>
+                <MidiRangeTarget
+                    ui_mode={self.props.midi_mode}
+                    onchange={self.link.callback(ChannelMsg::FaderChanged)}
+                >
                     <Fader
                         value={self.props.params.fader}
                         onchange={self.link.callback(ChannelMsg::FaderChanged)}

--- a/frontend/src/module/mixer.rs
+++ b/frontend/src/module/mixer.rs
@@ -2,6 +2,7 @@ use yew::{html, Component, ComponentLink, Html, ShouldRender, Properties, Callba
 
 use mixlab_protocol::{ModuleId, MixerParams, MixerChannelParams, ModuleParams, Decibel};
 
+use crate::component::midi_target::MidiRangeTarget;
 use crate::control::{Fader, Rotary};
 use crate::workspace::{Window, WindowMsg};
 
@@ -143,10 +144,12 @@ impl Component for Channel {
                 <div class={cue_style} onclick={self.link.callback(|_| ChannelMsg::CueClick)}>
                     {"CUE"}
                 </div>
-                <Fader
-                    value={self.props.params.fader}
-                    onchange={self.link.callback(ChannelMsg::FaderChanged)}
-                />
+                <MidiRangeTarget onchange={self.link.callback(ChannelMsg::FaderChanged)}>
+                    <Fader
+                        value={self.props.params.fader}
+                        onchange={self.link.callback(ChannelMsg::FaderChanged)}
+                    />
+                </MidiRangeTarget>
             </div>
         }
     }

--- a/frontend/src/module/mixer.rs
+++ b/frontend/src/module/mixer.rs
@@ -134,13 +134,19 @@ impl Component for Channel {
 
         html! {
             <div class="mixer-channel">
-                <Rotary<Decibel>
-                    value={self.props.params.gain}
-                    min={Decibel(-24.0)}
-                    max={Decibel(6.0)}
-                    default={Decibel(0.0)}
-                    onchange={self.link.callback(ChannelMsg::GainChanged)}
-                />
+                <MidiRangeTarget
+                    onchange={self.link.callback(|gain| {
+                        ChannelMsg::GainChanged(Decibel(gain * 30.0 - 24.0))
+                    })}
+                >
+                    <Rotary<Decibel>
+                        value={self.props.params.gain}
+                        min={Decibel(-24.0)}
+                        max={Decibel(6.0)}
+                        default={Decibel(0.0)}
+                        onchange={self.link.callback(ChannelMsg::GainChanged)}
+                    />
+                </MidiRangeTarget>
                 <div class={cue_style} onclick={self.link.callback(|_| ChannelMsg::CueClick)}>
                     {"CUE"}
                 </div>

--- a/frontend/src/service/midi.rs
+++ b/frontend/src/service/midi.rs
@@ -1,0 +1,199 @@
+use std::cell::RefCell;
+use std::collections::{HashMap, BTreeMap};
+use std::rc::Rc;
+use std::usize;
+
+use gloo_events::EventListener;
+use js_sys::Map;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{MidiInput, MidiMessageEvent};
+use yew::Callback;
+
+use crate::util::Sequence;
+
+struct MidiBroker {
+    inputs: HashMap<MidiInputId, MidiInput>,
+    listeners: HashMap<MidiInputId, EventListener>,
+    configuring: Option<ConfigureKind>,
+    id_seq: Sequence,
+    range_subscribers: BTreeMap<(MidiRangeId, usize), Callback<u8>>,
+}
+
+#[derive(Clone)]
+pub struct MidiBrokerRef(Rc<RefCell<MidiBroker>>);
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct MidiRangeId(MidiInputId, u8);
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct MidiNoteId(MidiInputId, u8);
+
+type MidiInputId = Rc<String>;
+
+thread_local! {
+    static BROKER: MidiBrokerRef = MidiBroker::new();
+}
+
+pub fn broker() -> MidiBrokerRef {
+    BROKER.with(|cell| cell.clone())
+}
+
+impl MidiBrokerRef {
+    pub fn configure_range(&self, callback: Callback<Option<(MidiRangeId, u8)>>) {
+        self.0.borrow_mut().configure(ConfigureKind::Range(callback));
+    }
+
+    pub fn subscribe_range(&self, range_id: MidiRangeId, callback: Callback<u8>) -> RangeSubscription {
+        let key = {
+            let mut broker = self.0.borrow_mut();
+            let subscription_id = broker.id_seq.next();
+            let key = (range_id, subscription_id);
+            broker.range_subscribers.insert(key.clone(), callback);
+            key
+        };
+
+        RangeSubscription {
+            broker: self.clone(),
+            key,
+        }
+    }
+
+    fn on_message(&self, input_id: MidiInputId, event: &MidiMessageEvent) {
+        let data = event.data().expect("MidiMessageEvent::data");
+
+        // MIDI controller (range) change message
+        if data.len() == 3 && (data[0] & 0xf0) == 0xb0 {
+            let range_id = MidiRangeId(input_id, data[1] & 0x7f);
+            let value = data[2] & 0x7f;
+
+            let min_key = (range_id.clone(), usize::MIN);
+            let max_key = (range_id.clone(), usize::MAX);
+
+            let mut subscribers = Vec::new();
+            let mut configuring = None;
+
+            {
+                let mut broker = self.0.borrow_mut();
+
+                for (_, callback) in broker.range_subscribers.range(min_key..=max_key) {
+                    subscribers.push(callback.clone());
+                }
+
+                if let Some(ConfigureKind::Range(callback)) = &broker.configuring {
+                    configuring = Some(callback.clone());
+                    broker.configuring = None;
+                }
+            }
+
+            for callback in subscribers {
+                callback.emit(value);
+            }
+
+            if let Some(callback) = configuring {
+                callback.emit(Some((range_id, value)));
+            }
+        }
+    }
+}
+
+impl MidiBroker {
+    pub fn new() -> MidiBrokerRef {
+        let broker = MidiBrokerRef(Rc::new(RefCell::new(MidiBroker {
+            inputs: HashMap::new(),
+            listeners: HashMap::new(),
+            configuring: None,
+            id_seq: Sequence::new(),
+            range_subscribers: BTreeMap::new(),
+        })));
+
+        wasm_bindgen_futures::spawn_local({
+            let broker = broker.clone();
+            async move {
+                setup(broker).await
+                    .expect("setup");
+            }
+        });
+
+        broker
+    }
+
+    fn configure(&mut self, configure: ConfigureKind) {
+        if let Some(previous) = self.configuring.take() {
+            match previous {
+                ConfigureKind::Range(cb) => cb.emit(None),
+            }
+        }
+
+        self.configuring = Some(configure);
+    }
+}
+
+pub struct RangeSubscription {
+    broker: MidiBrokerRef,
+    key: (MidiRangeId, usize),
+}
+
+impl Drop for RangeSubscription {
+    fn drop(&mut self) {
+        self.broker.0.borrow_mut().range_subscribers.remove(&self.key);
+    }
+}
+
+enum ConfigureKind {
+    Range(Callback<Option<(MidiRangeId, u8)>>),
+    // Note(Callback<Option<MidiNoteId>>),
+}
+
+async fn request_midi_access() -> Result<web_sys::MidiAccess, JsValue> {
+    Ok(JsFuture::from(web_sys::window()
+        .expect("web_sys::window")
+        .navigator()
+        .request_midi_access()
+        .expect("navigator.request_midi_access"))
+        .await?
+        .dyn_into::<web_sys::MidiAccess>()?)
+}
+
+async fn setup_input(broker: MidiBrokerRef, input: MidiInput) -> Result<(), JsValue> {
+    let input_id = Rc::new(input.id());
+
+    let event_listener = EventListener::new(&input, "midimessage", {
+        let input_id = input_id.clone();
+        let broker = broker.clone();
+        move |ev| {
+            let message = ev.dyn_ref::<MidiMessageEvent>()
+                .expect("dyn_into MidiMessageEvent");
+
+            broker.on_message(input_id.clone(), message);
+        }
+    });
+
+    let mut broker = broker.0.borrow_mut();
+    broker.inputs.insert(input_id.clone(), input);
+    broker.listeners.insert(input_id.clone(), event_listener);
+
+    Ok(())
+}
+
+async fn setup(broker: MidiBrokerRef) -> Result<(), JsValue> {
+    let midi = request_midi_access().await?;
+
+    let inputs = midi.inputs()
+        // MidiInputMap is not instanceof a Map, but is defined to adhere to
+        // the same interface for read-only methods:
+        .unchecked_into::<Map>();
+
+    let inputs = js_sys::try_iter(&inputs.values())
+        .expect("inputs try_iter")
+        .expect("inputs try_iter");
+
+    for input in inputs {
+        let input = input?.dyn_into::<MidiInput>()
+            .expect("dyn_into MidiInput");
+
+        setup_input(broker.clone(), input).await?;
+    }
+
+    Ok(())
+}

--- a/frontend/src/service/mod.rs
+++ b/frontend/src/service/mod.rs
@@ -1,0 +1,1 @@
+pub mod midi;

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -51,22 +51,43 @@ body {
     line-height:20px;
 }
 
-.module-window-title-delete {
+.module-window-title-button {
     font-size:14px;
     font-weight:bold;
-    margin-left:16px;
+    margin-left:8px;
     border:1px solid #c9c8d9;
     color:#c9c8d9;
-    width:16px;
     height:16px;
     line-height:16px;
     text-align:center;
     cursor:pointer;
 }
 
-.module-window-title-delete:hover {
+.module-window-title-button:hover {
     color:#dcdce7;
     border-color:#dcdce7;
+}
+
+.module-window-title-midi-btn {
+    font-size:12px;
+    padding:0px 4px;
+}
+
+.module-window-title-midi-btn-active {
+    font-size:12px;
+    padding:0px 4px;
+    background-color:#ffffff;
+    border-color:#ffffff;
+    color:#8d8bb0;
+}
+
+.module-window-title-midi-btn-active:hover {
+    border-color:#ffffff;
+    color:#8d8bb0;
+}
+
+.module-window-title-delete {
+    width:16px;
 }
 
 .module-window-content {
@@ -271,4 +292,46 @@ body {
     color:#ffffff;
     background-color:#ff003a;
     font-weight:bold;
+}
+
+.midi-target {
+    position:relative;
+}
+
+.midi-target-overlay {
+    position:absolute;
+    z-index:1;
+    left:0px;
+    top:0px;
+    width:100%;
+    height:100%;
+    opacity:50%;
+    cursor:pointer;
+    display:none;
+}
+
+.midi-mode-enabled .midi-target-overlay {
+    display:block;
+}
+
+.midi-mode-enabled .midi-target-overlay-unbound {
+    background-color:#e0a5a3;
+}
+
+.midi-mode-enabled .midi-target-overlay-unbound:hover {
+    background-color:#f0b5b3;
+}
+
+.midi-mode-enabled .midi-target-overlay-configure {
+    box-sizing:border-box;
+    background-color:#a3a5e0;
+    border:4px solid #373aa2;
+}
+
+.midi-mode-enabled .midi-target-overlay-bound {
+    background-color:#a3e0a5;
+}
+
+.midi-mode-enabled .midi-target-overlay-bound:hover {
+    background-color:#b3f0b5;
 }

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -306,42 +306,43 @@ body {
     width:100%;
     height:100%;
     opacity:50%;
-    cursor:pointer;
-    display:none;
-}
-
-.midi-mode-enabled .midi-target-overlay {
     display:block;
 }
 
-.midi-mode-enabled .midi-target-overlay-unbound {
+.midi-target-cfg-overlay {
+    cursor:pointer;
+}
+
+.midi-target-overlay-bound {
+    background-color:#eeeeee;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+}
+
+.midi-target-overlay-label {
+    background-color:#ffffff;
+    padding:4px 8px;
+}
+
+.midi-target-cfg-overlay-unbound {
     background-color:#e0a5a3;
 }
 
-.midi-mode-enabled .midi-target-overlay-unbound:hover {
+.midi-target-cfg-overlay-unbound:hover {
     background-color:#f0b5b3;
 }
 
-.midi-mode-enabled .midi-target-overlay-configure {
+.midi-target-cfg-overlay-configure {
     box-sizing:border-box;
     background-color:#a3a5e0;
     border:4px solid #373aa2;
 }
 
-.midi-target-overlay-bound {
-    /* always display bound overlay even if UI is not in midi mode */
-    display:block;
-    background-color:#aaaaaa;
-}
-
-.midi-mode-enabled .midi-target-overlay-bound {
+.midi-target-cfg-overlay-bound {
     background-color:#a3e0a5;
 }
 
-.midi-mode-enabled .midi-target-overlay-bound:hover {
+.midi-target-cfg-overlay-bound:hover {
     background-color:#b3f0b5;
-}
-
-.midi-mode-enabled .midi-target-overlay-label {
-    display:none;
 }

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -328,10 +328,20 @@ body {
     border:4px solid #373aa2;
 }
 
+.midi-target-overlay-bound {
+    /* always display bound overlay even if UI is not in midi mode */
+    display:block;
+    background-color:#aaaaaa;
+}
+
 .midi-mode-enabled .midi-target-overlay-bound {
     background-color:#a3e0a5;
 }
 
 .midi-mode-enabled .midi-target-overlay-bound:hover {
     background-color:#b3f0b5;
+}
+
+.midi-mode-enabled .midi-target-overlay-label {
+    display:none;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,9 +98,9 @@ async fn session(websocket: WebSocket, engine: Arc<EngineHandle>) {
                 let msg = bincode::deserialize::<ClientMessage>(msg.as_bytes())
                     .expect("bincode::deserialize");
 
-                println!("{:?}", msg);
-                let result = engine.update(msg);
-                println!(" => {:?}", result);
+                if let Err(e) = engine.update(msg) {
+                    println!("Engine update failed: {:?}", e);
+                }
             }
             Event::EngineOp(Err(broadcast::RecvError::Lagged(skipped))) => {
                 println!("disconnecting client: lagged {} messages behind", skipped);


### PR DESCRIPTION
Still to do:

- [x] Wire up gain knobs
- [ ] Wire up note on/off for buttons
- [x] Add MIDI overlay on controlled inputs in UI
- [x] Handle devices being added/removed dynamically
- [x] Make midi targets in configuring state lose configuring state when the MIDI UI mode is turned off
- [x] Degrade gracefully on browsers not supporting WebMIDI