### PR TITLE
Introduce PureModule abstraction

### DIFF
--- a/frontend/src/component/mod.rs
+++ b/frontend/src/component/mod.rs
@@ -1,2 +1,3 @@
 pub mod drag_target;
+pub mod pure_module;
 pub mod scroll_target;

--- a/frontend/src/component/pure_module.rs
+++ b/frontend/src/component/pure_module.rs
@@ -1,0 +1,42 @@
+use std::mem;
+use yew::{Component, ComponentLink, Html, ShouldRender, Properties};
+use mixlab_protocol::ModuleId;
+use crate::workspace::Window;
+
+pub trait PureModule: Clone + PartialEq + 'static {
+    fn view(&self, id: ModuleId, module: ComponentLink<Window>) -> Html;
+}
+
+#[derive(Properties, Clone)]
+pub struct PureProps<Params: PureModule> {
+    pub id: ModuleId,
+    pub params: Params,
+    pub module: ComponentLink<Window>,
+}
+
+pub struct Pure<Params: PureModule> {
+    props: PureProps<Params>
+}
+
+impl<Params: PureModule> Component for Pure<Params> {
+    type Properties = PureProps<Params>;
+    type Message = ();
+
+    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+        Self { props }
+    }
+
+    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
+        false
+    }
+
+    fn change(&mut self, mut props: Self::Properties) -> ShouldRender {
+        mem::swap(&mut self.props, &mut props);
+
+        self.props.id != props.id || self.props.params != props.params
+    }
+
+    fn view(&self) -> Html {
+        self.props.params.view(self.props.id, self.props.module.clone())
+    }
+}

--- a/frontend/src/module/amplifier.rs
+++ b/frontend/src/module/amplifier.rs
@@ -1,44 +1,20 @@
-use yew::{html, Component, ComponentLink, Html, ShouldRender, Properties};
+use yew::{html, ComponentLink, Html};
 use yew::events::ChangeData;
 
 use mixlab_protocol::{ModuleId, ModuleParams, AmplifierParams};
 
 use crate::workspace::{Window, WindowMsg};
+use crate::component::pure_module::{Pure, PureModule};
 
-#[derive(Properties, Clone, Debug)]
-pub struct AmplifierProps {
-    pub id: ModuleId,
-    pub module: ComponentLink<Window>,
-    pub params: AmplifierParams,
-}
+pub type Amplifier = Pure<AmplifierParams>;
 
-pub struct Amplifier {
-    props: AmplifierProps,
-}
+impl PureModule for AmplifierParams {
+    fn view(&self, id: ModuleId, module: ComponentLink<Window>) -> Html {
+        let amp_id = format!("w{}-amp", id.0);
+        let amp_params = self.clone();
 
-impl Component for Amplifier {
-    type Properties = AmplifierProps;
-    type Message = ();
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let amp_id = format!("w{}-amp", self.props.id.0);
-        let amp_params = self.props.params.clone();
-
-        let mod_id = format!("w{}-mod", self.props.id.0);
-        let mod_params = self.props.params.clone();
+        let mod_id = format!("w{}-mod", id.0);
+        let mod_params = self.clone();
 
         html! {
             <>
@@ -48,7 +24,7 @@ impl Component for Amplifier {
                     min={0}
                     max={1}
                     step={0.01}
-                    onchange={self.props.module.callback(move |ev| {
+                    onchange={module.callback(move |ev| {
                         if let ChangeData::Value(amplitude_str) = ev {
                             let amplitude = amplitude_str.parse().unwrap_or(0.0);
                             let params = AmplifierParams { amplitude, ..amp_params };
@@ -58,7 +34,7 @@ impl Component for Amplifier {
                             unreachable!()
                         }
                     })}
-                    value={self.props.params.amplitude}
+                    value={self.amplitude}
                 />
                 <label for={&mod_id}>{"Mod Depth"}</label>
                 <input type="range"
@@ -66,7 +42,7 @@ impl Component for Amplifier {
                     min={0}
                     max={1}
                     step={0.01}
-                    onchange={self.props.module.callback(move |ev| {
+                    onchange={module.callback(move |ev| {
                         if let ChangeData::Value(mod_str) = ev {
                             let mod_depth = mod_str.parse().unwrap_or(0.0);
                             let params = AmplifierParams { mod_depth, ..mod_params };
@@ -76,7 +52,7 @@ impl Component for Amplifier {
                             unreachable!()
                         }
                     })}
-                    value={self.props.params.mod_depth}
+                    value={self.mod_depth}
                 />
             </>
         }

--- a/frontend/src/module/fm_sine.rs
+++ b/frontend/src/module/fm_sine.rs
@@ -1,49 +1,25 @@
-use yew::{html, Component, ComponentLink, Html, ShouldRender, Properties};
+use yew::{html, ComponentLink, Html};
 use yew::events::ChangeData;
 
 use mixlab_protocol::{ModuleId, ModuleParams, FmSineParams};
 
 use crate::workspace::{Window, WindowMsg};
+use crate::component::pure_module::{Pure, PureModule};
 
-#[derive(Properties, Clone, Debug)]
-pub struct FmSineProps {
-    pub id: ModuleId,
-    pub module: ComponentLink<Window>,
-    pub params: FmSineParams,
-}
+pub type FmSine = Pure<FmSineParams>;
 
-pub struct FmSine {
-    props: FmSineProps,
-}
-
-impl Component for FmSine {
-    type Properties = FmSineProps;
-    type Message = ();
-
-    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Self { props }
-    }
-
-    fn update(&mut self, _msg: Self::Message) -> ShouldRender {
-        false
-    }
-
-    fn change(&mut self, props: Self::Properties) -> ShouldRender {
-        self.props = props;
-        true
-    }
-
-    fn view(&self) -> Html {
-        let freq_lo_id = format!("w{}-fmsine-freqlo", self.props.id.0);
-        let freq_hi_id = format!("w{}-fmsine-freqhi", self.props.id.0);
-        let params = self.props.params.clone();
+impl PureModule for FmSineParams {
+    fn view(&self, id: ModuleId, module: ComponentLink<Window>) -> Html {
+        let freq_lo_id = format!("w{}-fmsine-freqlo", id.0);
+        let freq_hi_id = format!("w{}-fmsine-freqhi", id.0);
+        let params = self.clone();
 
         html! {
             <>
                 <label for={&freq_lo_id}>{"Freq Lo"}</label>
                 <input type="number"
                     id={&freq_lo_id}
-                    onchange={self.props.module.callback({
+                    onchange={module.callback({
                         let params = params.clone();
                         move |ev| {
                             if let ChangeData::Value(freq_str) = ev {
@@ -56,13 +32,13 @@ impl Component for FmSine {
                             }
                         }
                     })}
-                    value={self.props.params.freq_lo}
+                    value={self.freq_lo}
                 />
 
                 <label for={&freq_hi_id}>{"Freq Hi"}</label>
                 <input type="number"
                     id={&freq_hi_id}
-                    onchange={self.props.module.callback({
+                    onchange={module.callback({
                         let params = params.clone();
                         move |ev| {
                             if let ChangeData::Value(freq_str) = ev {
@@ -75,7 +51,7 @@ impl Component for FmSine {
                             }
                         }
                     })}
-                    value={self.props.params.freq_hi}
+                    value={self.freq_hi}
                 />
             </>
         }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -211,7 +211,7 @@ pub struct FmSineParams {
     pub freq_hi: f64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct AmplifierParams {
     pub amplitude: f64,
     pub mod_depth: f64,

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -205,7 +205,7 @@ pub struct PlotterIndication {
     pub inputs: Vec<Vec<Sample>>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct FmSineParams {
     pub freq_lo: f64,
     pub freq_hi: f64,


### PR DESCRIPTION
Most modules aren't very complicated on the frontend. They're pretty much just a pure function of the module's params that also knows how to send messages up the chain on change.

This pull request introduces a new trait `PureModule` that can be impl'd directly on the module params struct with only a `view` method and a `Pure` wrapper that turns `PureModule`s into well behaving `Component`s.

I've left the `id` and `module` parameters for now, but I also plan on getting rid of the `id` param and replacing `module` with a `Callback` parameter to decouple modules from windows