### PR TITLE
Add Pulse waveform and pulse width modulation (PWM) via input, applicable to all oscillator waveforms

### DIFF
--- a/frontend/src/module/oscillator.rs
+++ b/frontend/src/module/oscillator.rs
@@ -48,6 +48,7 @@ impl Component for Oscillator {
                     Waveform::Square => "Square",
                     Waveform::Saw => "Sawtooth",
                     Waveform::Triangle => "Triangle",
+                    Waveform::Pulse => "Pulse",
                     Waveform::On => "High",
                     Waveform::Off => "Zero",
                 };
@@ -60,6 +61,7 @@ impl Component for Oscillator {
             SelectableWaveform(Waveform::Square),
             SelectableWaveform(Waveform::Saw),
             SelectableWaveform(Waveform::Triangle),
+            SelectableWaveform(Waveform::Pulse),
             SelectableWaveform(Waveform::On),
             SelectableWaveform(Waveform::Off),
         ];

--- a/frontend/src/module/oscillator.rs
+++ b/frontend/src/module/oscillator.rs
@@ -4,7 +4,7 @@ use yew::{html, Component, ComponentLink, Html, ShouldRender, Properties};
 use yew::events::ChangeData;
 use yew::components::Select;
 
-use mixlab_protocol::{ModuleId, ModuleParams, OscillatorParams, Waveform};
+use mixlab_protocol::{ModuleId, ModuleParams, OscillatorParams, Waveform, Frequency};
 
 use crate::workspace::{Window, WindowMsg};
 
@@ -65,6 +65,8 @@ impl Component for Oscillator {
         ];
 
         let params = self.props.params.clone();
+        let hz = self.props.params.freq.to_hz().value();
+        let bpm = self.props.params.freq.to_bpm().value();
 
         html! {
             <>
@@ -87,19 +89,41 @@ impl Component for Oscillator {
                     />
                 </label>
                 <label>
-                    <div>{"Frequency"}</div>
+                    <div>{"Frequency (Hz)"}</div>
                     <input type="number"
-                        onchange={self.props.module.callback(move |ev| {
-                            if let ChangeData::Value(freq_str) = ev {
-                                let freq = freq_str.parse().unwrap_or(0.0);
-                                let params = OscillatorParams { freq, ..params };
-                                WindowMsg::UpdateParams(
-                                    ModuleParams::Oscillator(params))
-                            } else {
-                                unreachable!()
+                        onchange={self.props.module.callback({
+                            let params = self.props.params.clone();
+                            move |ev| {
+                                if let ChangeData::Value(freq_str) = ev {
+                                    let freq = freq_str.parse().unwrap_or(0.0);
+                                    let params = OscillatorParams { freq: Frequency::Hz(freq), ..params };
+                                    WindowMsg::UpdateParams(
+                                        ModuleParams::Oscillator(params))
+                                } else {
+                                    unreachable!()
+                                }
                             }
                         })}
-                        value={self.props.params.freq}
+                        value={hz}
+                    />
+                </label>
+                <label>
+                    <div>{"BPM"}</div>
+                    <input type="number"
+                        onchange={self.props.module.callback({
+                            let params = self.props.params.clone();
+                            move |ev| {
+                                if let ChangeData::Value(freq_str) = ev {
+                                    let freq = freq_str.parse().unwrap_or(0.0);
+                                    let params = OscillatorParams { freq: Frequency::BPM(freq), ..params };
+                                    WindowMsg::UpdateParams(
+                                        ModuleParams::Oscillator(params))
+                                } else {
+                                    unreachable!()
+                                }
+                            }
+                        })}
+                        value={bpm}
                     />
                 </label>
             </>

--- a/frontend/src/workspace.rs
+++ b/frontend/src/workspace.rs
@@ -460,7 +460,7 @@ impl Workspace {
         };
 
         let items = &[
-            ("Oscillator", ModuleParams::Oscillator(OscillatorParams { freq: Frequency::Hz(100.0), waveform: Waveform::Sine, pulse_width: 0.25 })),
+            ("Oscillator", ModuleParams::Oscillator(OscillatorParams { freq: Frequency::Hz(100.0), waveform: Waveform::Sine, pulse_width: None })),
             ("Mixer (2 channel)", ModuleParams::Mixer(MixerParams::with_channels(2))),
             ("Mixer (4 channel)", ModuleParams::Mixer(MixerParams::with_channels(4))),
             ("Mixer (8 channel)", ModuleParams::Mixer(MixerParams::with_channels(8))),

--- a/frontend/src/workspace.rs
+++ b/frontend/src/workspace.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::JsCast;
 use web_sys::{CanvasRenderingContext2d, HtmlElement, HtmlCanvasElement, MouseEvent};
 use yew::{html, Callback, Component, ComponentLink, Html, ShouldRender, Properties, NodeRef};
 
-use mixlab_protocol::{ModuleId, TerminalId, InputId, OutputId, ModuleParams, OscillatorParams, Waveform, ClientOp, WindowGeometry, Coords, Indication, OutputDeviceParams, FmSineParams, AmplifierParams, GateState, LineType, EnvelopeParams, MixerParams, IcecastInputParams};
+use mixlab_protocol::{ModuleId, TerminalId, InputId, OutputId, ModuleParams, OscillatorParams, Waveform, Frequency, ClientOp, WindowGeometry, Coords, Indication, OutputDeviceParams, FmSineParams, AmplifierParams, GateState, LineType, EnvelopeParams, MixerParams, IcecastInputParams};
 
 use crate::module::amplifier::Amplifier;
 use crate::module::envelope::Envelope;
@@ -460,7 +460,7 @@ impl Workspace {
         };
 
         let items = &[
-            ("Oscillator", ModuleParams::Oscillator(OscillatorParams { freq: 100.0, waveform: Waveform::Sine })),
+            ("Oscillator", ModuleParams::Oscillator(OscillatorParams { freq: Frequency::Hz(100.0), waveform: Waveform::Sine, pulse_width: 0.25 })),
             ("Mixer (2 channel)", ModuleParams::Mixer(MixerParams::with_channels(2))),
             ("Mixer (4 channel)", ModuleParams::Mixer(MixerParams::with_channels(4))),
             ("Mixer (8 channel)", ModuleParams::Mixer(MixerParams::with_channels(8))),

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -207,7 +207,7 @@ impl Frequency {
 pub struct OscillatorParams {
     pub freq: Frequency,
     pub waveform: Waveform,
-    pub pulse_width: f64,
+    pub pulse_width: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -174,9 +174,39 @@ pub enum Waveform {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum Frequency {
+    Hz(f64),
+    BPM(f64),
+}
+
+impl Frequency {
+    pub fn to_hz(&self) -> Self {
+        match self {
+            Self::Hz(_) => self.clone(),
+            Self::BPM(bpm) => Self::Hz(bpm / 60.0),
+        }
+    }
+
+    pub fn to_bpm(&self) -> Self {
+        match self {
+            Self::Hz(hz) => Self::BPM(hz * 60.0),
+            Self::BPM(_) => self.clone(),
+        }
+    }
+
+    pub fn value(&self) -> f64 {
+        match self {
+            Self::Hz(hz) => *hz,
+            Self::BPM(bpm) => *bpm,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct OscillatorParams {
-    pub freq: f64,
+    pub freq: Frequency,
     pub waveform: Waveform,
+    pub pulse_width: f64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -171,6 +171,7 @@ pub enum Waveform {
     Square,
     Triangle,
     Saw,
+    Pulse,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/module/oscillator.rs
+++ b/src/module/oscillator.rs
@@ -1,6 +1,6 @@
 use std::f64;
 
-use mixlab_protocol::{OscillatorParams, Waveform, LineType, Terminal};
+use mixlab_protocol::{OscillatorParams, Waveform, LineType, Terminal, Frequency};
 
 use crate::engine::{Sample, SAMPLE_RATE};
 use crate::module::ModuleT;
@@ -66,10 +66,11 @@ impl ModuleT for Oscillator {
         const STEREO: usize = 1;
 
         let len = outputs[MONO].len();
+        let hz = self.params.freq.to_hz().value();
 
         for i in 0..len {
             let t0 = (t + i as u64) as f64 / SAMPLE_RATE as f64;
-            let n = t0 * self.params.freq as f64;
+            let n = t0 * hz as f64;
 
             let sample: f32 = match &self.params.waveform {
                 Waveform::Sine => sine(n),


### PR DESCRIPTION
* Display oscillator frequency in terms of BPM. Each waveform has one logical "peak" per cycle. That cycle is in terms of time. Those peaks can be considered beats, so this just lets you set a frequency in terms of beats for doing percussive/clock effects vs tone manipulation.
* Add Pulse waveform, which is high for 20% of its cycle, and zero for the rest, unless a different PWM threshold is provided.
* Allow configurable output width via PWM terminal input. Positive pulse widths mask all signal past the threshold. Negative pulse widths do the same, but they invert the signal.

This might unhelpfully conflate some concepts that we'd rather keep separate. I'm loosely looking at real world oscillators, such as https://www.synthesizers.com/q106a.html and noting the presence of pulse width control on them.

I think whether or not this merges, there should definitely be separate Clock and PWM modules with their own frequency controls. But, this could continue in some form sharing some of the mechanics.

So... totally open to this being not a useful direction!